### PR TITLE
Updated async version to ^1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "main": "./lib",
   "dependencies": {
-    "async": "^0.9.0",
+    "async": "^1.5.0",
     "express-unless": "^0.3.0",
     "jsonwebtoken": "^5.0.0",
     "lodash": "~3.10.1",


### PR DESCRIPTION
We experienced some issues with using the latest version of express-jwt in our environment in conjunction with mochajs and supertest.

After some digging we were able to identify the issue in the `async.waterfall` call. For some reasons, when the `async.setImmediate` method is called the execution died. 

Then we found this issue in the async library: https://github.com/caolan/async/issues/696.

So, we updated async used by express-jwt to 1.5.0 (latest) and the problem was fixed.
